### PR TITLE
add index.ts to root

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './src';


### PR DESCRIPTION
I don't actually understand how the project is built and published to NPM, but I think this change will allow me to `npm install angular2-openlayers` and subsequently `import { AngularOpenlayersModule } from 'angular2-openlayers';` in my code. Currently this does not work. I looked at some other NPM packages and they typically have an `index.js` or `index.d.ts` in the package root for this purpose.