### PR TITLE
map command service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ npm-debug.log
 # Windows
 Thumbs.db
 Desktop.ini
+.vscode/*
 
 # Mac
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-openlayers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",

--- a/src/components/layer.components.ts
+++ b/src/components/layer.components.ts
@@ -1,13 +1,16 @@
-import { Component, Host, OnDestroy } from '@angular/core';
+import { Component, Host, OnDestroy, Input } from '@angular/core';
 import { layer } from 'openlayers';
 import { MapComponent } from "./map.component";
-
 
 @Component({
   selector: 'aol-layer-tile',
   template: `<ng-content></ng-content>`
 })
 export class LayerTileComponent extends layer.Tile implements OnDestroy{
+    @Input() set name(value: string) {
+        this.set('name', value);
+    }
+
   _host_: MapComponent;
 
   constructor(@Host() map: MapComponent){
@@ -28,6 +31,10 @@ export class LayerTileComponent extends layer.Tile implements OnDestroy{
   template: `<ng-content></ng-content>`
 })
 export class LayerVectorComponent extends layer.Vector implements OnDestroy{
+    @Input() set name(value: string) {
+        this.set('name', value);
+    }
+
   _host_: MapComponent;
 
   constructor(@Host() map: MapComponent){

--- a/src/components/map.component.ts
+++ b/src/components/map.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef, Output, EventEmitter } from '@angular/core';
+import { Component, ElementRef, Output, EventEmitter, Optional } from '@angular/core';
 import { Map, MapBrowserEvent,MapEvent, render, ObjectEvent } from 'openlayers';
+import { MapCommandService } from '../services/map-command.service';
 
 @Component({
   selector: 'aol-map',
@@ -20,7 +21,9 @@ export class MapComponent extends Map {
   @Output() onPropertyChange = new EventEmitter<ObjectEvent>();
   @Output() onSingleClick = new EventEmitter<MapBrowserEvent>();
 
-  constructor(element: ElementRef){
+  constructor(
+    element: ElementRef,
+    @Optional() private mapCommandService: MapCommandService){
     super({target: null, controls: []});
     this._host_ = element;
   }
@@ -29,6 +32,9 @@ export class MapComponent extends Map {
   	this.setTarget(this._host_.nativeElement.firstElementChild);
   	this.updateSize();
     this.addEvents();
+    if (this.mapCommandService) {
+      this.mapCommandService.registerMap(this);
+    }
   }
 
   private addEvents() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {CommonModule} from '@angular/common';
 import {COMPONENTS} from './components';
 
 export * from './components';
+export * from './services';
 export default {
   components: [COMPONENTS]
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,1 @@
+export { MapCommandService } from './map-command.service';

--- a/src/services/map-command.service.ts
+++ b/src/services/map-command.service.ts
@@ -1,0 +1,39 @@
+// Service that exposes map commands to container components
+// See https://angular.io/docs/ts/latest/cookbook/component-communication.html#bidirectional-service
+
+import { Injectable } from '@angular/core';
+import { Extent, Map, Pixel, Coordinate, extent } from 'openlayers';
+
+@Injectable()
+export class MapCommandService {
+    // We don't want to compromise the MVC design of Angular 2, but
+    // with OpenLayers there will always be times when the application
+    // needs to interact directly with the map. For these limited
+    // cases this service can be used.
+
+    private map: Map;
+
+    registerMap(map: Map) {
+        this.map = map;
+    }
+
+    getCoordinateFromPixel = (pixel: Pixel) => this.map.getCoordinateFromPixel(pixel);
+    getPixelFromCoordinate = (coordinate: Coordinate) => this.map.getPixelFromCoordinate(coordinate);
+
+    zoomToExtent(zoomExtent: Extent) {
+        let isSinglePoint = zoomExtent[0] === zoomExtent[2] && zoomExtent[1] === zoomExtent[3];
+        if (isSinglePoint) {
+            zoomExtent = extent.buffer(zoomExtent, 200); // use a 200m buffer when zooming to a single point
+        }
+        this.map.getView().fit(zoomExtent, this.map.getSize());
+    }
+
+    zoomToLayerExtent(layerName: string) {
+        this.map.getLayers().forEach((layer: any) => {
+            if (layer.getSource && layer.get('name') === layerName) {
+                let zoomExtent = layer.getSource().getExtent();
+                this.zoomToExtent(zoomExtent);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Creates a map service that can be added to the `providers` collection of the containing component, for issuing commands/requests to the map. Currently supported commands:
- `getCoordinateFromPixel`
- `getPixelFromCoordinate`
- `zoomToExtent`
- `zoomToLayerExtent`