### PR TITLE
static openlayers dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "dependencies": {
-    "openlayers": "^3.18.2",
+    "openlayers": "3.18.2",
     "@angular/common": "^2.0.1",
     "@angular/core": "^2.0.1",
-    "@types/openlayers": "^3.18.38",
+    "@types/openlayers": "3.18.38",
     "rxjs": "5.0.0-beta.12"
   },
   "devDependencies": {


### PR DESCRIPTION
made the dependency of openlayer static because I get the following error running ```npm run prepublish``` since ol v3.20.0:
```
src/components/style.components.ts(62,35): error TS2345: Argument of type '{ anchor: [number, number]; anchorOrigin: string; anchorXUnits: string; anchorYUnits: string; col...' is not assignable to parameter of type 'IconOptions'.
  Types of property 'anchorOrigin' are incompatible.
    Type 'string' is not assignable to type 'IconOrigin'.
```

I'll try to fix this in an appropriate way as soon as I find the time for it.