### PR TITLE
Aot support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ Desktop.ini
 # Mac
 .DS_Store
 **/.DS_Store
+
+# Angular
+/aot
+*.metadata.json

--- a/.npmignore
+++ b/.npmignore
@@ -24,4 +24,4 @@ Desktop.ini
 **/.DS_Store
 
 # Angular
-/compiled
+/aot

--- a/.npmignore
+++ b/.npmignore
@@ -22,3 +22,6 @@ Desktop.ini
 # Mac
 .DS_Store
 **/.DS_Store
+
+# Angular
+/compiled

--- a/package.json
+++ b/package.json
@@ -28,20 +28,21 @@
     "typings": "./dist/index.d.ts",
     "dependencies": {
         "openlayers": "3.18.2",
-        "@types/openlayers": "3.18.38"
+        "@angular/platform-browser": "2.2.3",
+        "@angular/common": "2.2.3",
+        "@angular/core": "2.2.3",
+        "@types/openlayers": "3.18.38",
+        "rxjs": "5.0.0-beta.12"
     },
     "devDependencies": {
-        "@angular/common": "2.2.3",
         "@angular/compiler": "2.2.3",
         "@angular/compiler-cli": "2.2.3",
-        "@angular/core": "2.2.3",
         "@angular/platform-server": "2.2.3",
         "@types/es6-shim": "^0.31.32",
         "@types/jasmine": "^2.5.38",
         "@types/selenium-webdriver": "^2.53.33",
         "codelyzer": "2.0.0-beta.1",
-        "rxjs": "5.0.0-beta.12",
-        "tslint": "4.0.2",
+        "tslint": "~4.0.0",
         "typescript": "2.0.3",
         "zone.js": "0.6.23"
     },

--- a/package.json
+++ b/package.json
@@ -1,48 +1,51 @@
 {
-  "name": "angular2-openlayers",
-  "version": "0.4.0",
-  "scripts": {
-    "lint": "tslint src/**/*.ts",
-    "test": "tsc && karma start",
-    "prepublish": "tsc",
-    "tsc": "tsc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/quentin-ol/angular2-openlayers"
-  },
-  "author": {
-    "name": "Quentin Lampin",
-    "email": "quentin.lampin@orange.com"
-  },
-  "keywords": [
-    "angular",
-    "angular2",
-    "openlayers"
-  ],
-  "license": "MPL-2.0",
-  "bugs": {
-    "url": "https://github.com/quentin-ol/angular2-openlayers/issues"
-  },
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
-  "dependencies": {
-    "openlayers": "^3.18.2",
-    "@angular/common": "^2.0.1",
-    "@angular/core": "^2.0.1",
-    "@types/openlayers": "^3.18.38",
-    "rxjs": "5.0.0-beta.12"
-  },
-  "devDependencies": {
-    "@types/es6-shim": "^0.31.32",
-    "@types/jasmine": "^2.5.35",
-    "@types/selenium-webdriver": "^2.53.33",
-    "codelyzer": "^0.0.20",
-    "tslint": "^3.6.0",
-    "typescript": "2.0.2",
-    "zone.js": "^0.6.12"
-  },
-  "engines": {
-    "node": ">=0.8.0"
-  }
+    "name": "angular2-openlayers",
+    "version": "0.4.0",
+    "scripts": {
+        "lint": "tslint src/**/*.ts",
+        "test": "ngc && karma start",
+        "prepublish": "ngc",
+        "ngc": "ngc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/quentin-ol/angular2-openlayers"
+    },
+    "author": {
+        "name": "Quentin Lampin",
+        "email": "quentin.lampin@orange.com"
+    },
+    "keywords": [
+        "angular",
+        "angular2",
+        "openlayers"
+    ],
+    "license": "MPL-2.0",
+    "bugs": {
+        "url": "https://github.com/quentin-ol/angular2-openlayers/issues"
+    },
+    "main": "./dist/index.js",
+    "typings": "./dist/index.d.ts",
+    "dependencies": {
+        "openlayers": "3.18.2",
+        "@types/openlayers": "3.18.38"
+    },
+    "devDependencies": {
+        "@angular/common": "2.2.3",
+        "@angular/compiler": "2.2.3",
+        "@angular/core": "2.2.3",
+        "@angular/compiler-cli": "2.2.3",
+        "@angular/platform-server": "2.2.3",
+        "@types/es6-shim": "^0.31.32",
+        "@types/jasmine": "^2.5.38",
+        "@types/selenium-webdriver": "^2.53.33",
+        "codelyzer": "2.0.0-beta.1",
+        "rxjs": "5.0.0-beta.12",
+        "tslint": "4.0.2",
+        "typescript": "2.0.3",
+        "zone.js": "0.6.23"
+    },
+    "engines": {
+        "node": ">=0.8.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-openlayers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",

--- a/src/components.ts
+++ b/src/components.ts
@@ -8,7 +8,7 @@ import {FeatureComponent} from "./components/feature.component";
 import {GeometryLinestringComponent, GeometryPointComponent} from "./components/geometry.components";
 import {CoordinateComponent, CollectionCoordinatesComponent} from "./components/coordinate.component";
 import {StyleComponent, IconStyleDirective} from "./components/style.components";
-import {CONTROLS} from './components/controls/controls';
+import {controls} from './components/controls/controls';
 
 // Export all components
 export * from './components/map.component';
@@ -22,20 +22,22 @@ export * from './components/style.components';
 export * from './components/controls/controls';
 
 // Export convenience property
-export const COMPONENTS: any[] = [
-  MapComponent,
-  ViewComponent,
-  LayerTileComponent,
-  LayerVectorComponent,
-  SourceOsmComponent,
-  SourceBingmapsComponent,
-  SourceVectorComponent,
-  FeatureComponent,
-  GeometryLinestringComponent,
-  GeometryPointComponent,
-  CoordinateComponent,
-  CollectionCoordinatesComponent,
-  StyleComponent,
-  IconStyleDirective,
-  CONTROLS
-];
+export function components(): any[] {
+  return [
+    MapComponent,
+    ViewComponent,
+    LayerTileComponent,
+    LayerVectorComponent,
+    SourceOsmComponent,
+    SourceBingmapsComponent,
+    SourceVectorComponent,
+    FeatureComponent,
+    GeometryLinestringComponent,
+    GeometryPointComponent,
+    CoordinateComponent,
+    CollectionCoordinatesComponent,
+    StyleComponent,
+    IconStyleDirective,
+    controls()
+  ]
+};

--- a/src/components/controls/controls.ts
+++ b/src/components/controls/controls.ts
@@ -21,14 +21,16 @@ export * from './zoomslider.component';
 export * from './zoomtoextent.component';
 
 // Export convenience property
-export const CONTROLS: any[] = [
-    ControlAttributionComponent,
-    ControlFullScreenComponent,
-    ControlMousePositionComponent,
-    // ControlOverviewMapComponent,
-    ControlRotateComponent,
-    ControlScaleLineComponent,
-    ControlZoomComponent,
-    ControlZoomSliderComponent,
-    ControlZoomToExtentComponent
-];
+export function controls(): any[] {
+    return [
+        ControlAttributionComponent,
+        ControlFullScreenComponent,
+        ControlMousePositionComponent,
+        // ControlOverviewMapComponent,
+        ControlRotateComponent,
+        ControlScaleLineComponent,
+        ControlZoomComponent,
+        ControlZoomSliderComponent,
+        ControlZoomToExtentComponent
+    ]
+};

--- a/src/components/layer.components.ts
+++ b/src/components/layer.components.ts
@@ -1,8 +1,6 @@
 import {Component, Host, OnDestroy, OnInit} from '@angular/core';
 import { layer } from 'openlayers';
 import { MapComponent } from "./map.component";
-import TileOptions = olx.layer.TileOptions;
-import VectorOptions = olx.layer.VectorOptions;
 
 
 export class LayerComponent implements OnInit, OnDestroy {
@@ -30,7 +28,7 @@ export class LayerComponent implements OnInit, OnDestroy {
   selector: 'aol-layer-tile',
   template: `<ng-content></ng-content>`
 })
-export class LayerTileComponent extends LayerComponent implements TileOptions{
+export class LayerTileComponent extends LayerComponent {
   public source: ol.source.Tile;
 
   constructor(@Host() map: MapComponent){
@@ -44,7 +42,7 @@ export class LayerTileComponent extends LayerComponent implements TileOptions{
   selector: 'aol-layer-vector',
   template: `<ng-content></ng-content>`
 })
-export class LayerVectorComponent extends LayerComponent implements VectorOptions{
+export class LayerVectorComponent extends LayerComponent {
   public source: ol.source.Vector;
 
   constructor(@Host() map: MapComponent){

--- a/src/components/map.component.ts
+++ b/src/components/map.component.ts
@@ -27,6 +27,7 @@ export class MapComponent{
   @Output() onSingleClick: EventEmitter<MapBrowserEvent>;
 
   constructor(element: ElementRef){
+    console.log('instancing aol-map');
     this._host_ = element;
 
     this.options = {

--- a/src/components/source.components.ts
+++ b/src/components/source.components.ts
@@ -1,9 +1,6 @@
 import {Component, Host, OnDestroy, Input, OnInit} from '@angular/core';
 import { source } from 'openlayers';
 import {LayerTileComponent, LayerVectorComponent, LayerComponent} from "./layer.components";
-import BingMapsOptions = olx.source.BingMapsOptions;
-import OSMOptions = olx.source.OSMOptions;
-import VectorOptions = olx.source.VectorOptions;
 
 export class SourceComponent implements OnInit, OnDestroy {
   public host: LayerComponent;
@@ -25,7 +22,7 @@ export class SourceComponent implements OnInit, OnDestroy {
   selector: 'aol-source-osm',
   template: `<div class="aol-source-osm"></div>`
 })
-export class SourceOsmComponent extends SourceComponent implements OSMOptions{
+export class SourceOsmComponent extends SourceComponent {
 
   constructor(@Host() layer: LayerTileComponent){
     console.log('instancing aol-source-osm');
@@ -43,7 +40,7 @@ export class SourceOsmComponent extends SourceComponent implements OSMOptions{
   template: `<div class="aol-source-bingmaps"></div>`
 })
 
-export class SourceBingmapsComponent extends SourceComponent implements BingMapsOptions{
+export class SourceBingmapsComponent extends SourceComponent {
   @Input('key') key: string;
   @Input('imagerySet') imagerySet: 'Road'|'Aerial'|'AerialWithLabels'|'collinsBart'|'ordnanceSurvey';
 
@@ -63,7 +60,7 @@ export class SourceBingmapsComponent extends SourceComponent implements BingMaps
   selector: 'aol-source-vector',
   template: `<ng-content></ng-content>`
 })
-export class SourceVectorComponent extends SourceComponent implements VectorOptions{
+export class SourceVectorComponent extends SourceComponent {
 
   constructor(@Host() layer: LayerVectorComponent){
     console.log('instancing aol-source-vector');

--- a/src/components/source.components.ts
+++ b/src/components/source.components.ts
@@ -29,7 +29,7 @@ export class SourceOsmComponent extends source.OSM implements OnDestroy{
 })
 export class SourceBingmapsComponent extends source.BingMaps implements OnDestroy{
   _host_: LayerTileComponent;
-  
+
   @Input('key') key: string;
 
   constructor(@Host() layer: LayerTileComponent, key: string){

--- a/src/components/view.component.ts
+++ b/src/components/view.component.ts
@@ -1,13 +1,12 @@
 import { Component, Host, Input, OnChanges, OnDestroy } from '@angular/core';
 import { View } from 'openlayers';
 import { MapComponent } from "./map.component";
-import ViewOptions = olx.ViewOptions;
 
 @Component({
   selector: 'aol-view',
   template: `<ng-content></ng-content>`
 })
-export class ViewComponent implements ViewOptions, OnChanges, OnDestroy{
+export class ViewComponent implements OnChanges, OnDestroy{
   private _host_: MapComponent;
 
   public instance: View;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,12 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {COMPONENTS} from './components';
+import {components} from './components';
 
 export * from './components';
-export default {
-  components: [COMPONENTS]
-}
 
 @NgModule({
-  declarations: COMPONENTS,
+  declarations: components(),
   imports: [CommonModule],
-  exports: COMPONENTS
+  exports: components()
 })
 export class AngularOpenlayersModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,24 @@
 {
-  "compilerOptions": {
-    "noImplicitAny": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "ES5",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "sourceMap": true,
-    "declaration": true,
-    "outDir": "./dist"
-  },
-  "files": [
-    "src/index.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "module": "es2015",
+        "moduleResolution": "node",
+        "target": "es5",
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "sourceMap": true,
+        "declaration": true,
+        "outDir": "./dist"
+    },
+    "files": [
+        "src/index.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "angularCompilerOptions": {
+        "genDir": "aot",
+        "skipTemplateCodegen": true
+    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "dist"
     ],
     "angularCompilerOptions": {
-        "genDir": "aot"
+        "genDir": "aot",
+        "skipTemplateCodegen": true
     }
 }


### PR DESCRIPTION
Making this library aot friendly using [this guide](https://medium.com/@isaacplmann/getting-your-angular-2-library-ready-for-aot-90d1347bcad#.h3wqe3ai9)

I started this work as I think it has to be done sooner or later (rater sooner then later) and I think it might also solve the issue #19, since both throw the same exception.

I replaced the tsc compiler with the ngc compiler, did the needed changes in tsconfig.json, .gitignore and .npmignore and was able to compile resulting in all the metadata and factory files being generated, but when trying to build a small example using aot I still get the error: ```Unexpected value 'AngularOpenlayersModule' imported by the module 'AppModule'```. Currently I'm out of ideas, but I'll defenitly continue the research and try to finish it.
In the mean while I would appreciate any idea, link or other kind of help.