### PR TITLE
fix(example): add form to package.json

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,7 @@
     "@angular/compiler": "^2.4.0",
     "@angular/core": "^2.4.0",
     "@angular/http": "^2.4.0",
+    "@angular/forms": "^2.4.0",
     "@angular/platform-browser": "^2.4.0",
     "@angular/platform-browser-dynamic": "^2.4.0",
     "@angular/router": "^3.3.1",


### PR DESCRIPTION
To allow the example to be launch, a missing dependency is added to `package.json`