### PR TITLE
fix(types): upgrade types of OpenLayers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@angular/common": "2.4.1",
         "@angular/core": "2.4.1",
         "zone.js": "0.7.4",
-        "@types/openlayers": "3.20.0",
+        "@types/openlayers": "3.20.1",
         "rxjs": "5.0.2",
         "@angular/compiler": "2.4.1",
         "@angular/compiler-cli": "2.4.1",


### PR DESCRIPTION
An error occurred when you try to build the application due to wrong version of typings for OpenLayers. Some methods used in the StyleComponent object were not defined. The ngc build returned the following errors : 
```
Error at /Users/kdavin/Workspace/Airbus/webfactory/angular-openlayers/src/components/style.components.ts:60:21: Property 'setRadius' does not exist on type 'Circle'.
Error at /Users/kdavin/Workspace/Airbus/webfactory/angular-openlayers/src/components/style.components.ts:67:24: Property 'setImage' does not exist on type 'Style'.
Error at /Users/kdavin/Workspace/Airbus/webfactory/angular-openlayers/src/components/style.components.ts:73:43: Property 'setRadius' does not exist on type 'Circle'.
Error at /Users/kdavin/Workspace/Airbus/webfactory/angular-openlayers/src/components/style.components.ts:79:24: Property 'setImage' does not exist on type 'Style'.
```