### PR TITLE
Revert "fixed not updating size"

### DIFF
--- a/dist/components/map.component.js
+++ b/dist/components/map.component.js
@@ -59,7 +59,7 @@ var MapComponent = (function () {
         // console.log('changes detected in aol-map, setting new properties: ', properties);
         this.instance.setProperties(properties, false);
     };
-    MapComponent.prototype.ngAfterViewChecked = function () {
+    MapComponent.prototype.ngAfterViewInit = function () {
         this.instance.updateSize();
     };
     return MapComponent;

--- a/src/components/map.component.ts
+++ b/src/components/map.component.ts
@@ -84,7 +84,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
     this.instance.setProperties(properties, false);
   }
 
-  ngAfterViewChecked() {
+  ngAfterViewInit() {
     this.instance.updateSize();
   }
 }


### PR DESCRIPTION
 PR #53 raises three issues that I haven't seen at first.

1. AfterViewChecked is not imported. (ngc didn't catch it at first!)
2. the ngAfterViewChecked callback is called too frequently causing high CPU usages.
3. when using a md-sidenav layout (material-design) where the map is the sole main content that extends to the bottom of the page, the updateSize method is called repeatedly and and the map scrolls upwards endlessly.

