### PR TITLE
Geojson source

### DIFF
--- a/src/components/sources/geojson.component.ts
+++ b/src/components/sources/geojson.component.ts
@@ -1,0 +1,32 @@
+import { Component, Host, Input, OnInit, forwardRef, ContentChild, AfterContentInit } from '@angular/core';
+import { source, ProjectionLike, format } from 'openlayers';
+import { LayerVectorComponent } from '../layers';
+import { FormatComponent } from '../formats';
+import { SourceComponent } from './source.component';
+
+
+@Component({
+    selector: 'aol-source-geojson',
+    template: `<ng-content></ng-content>`,
+    providers: [
+        { provide: SourceComponent, useExisting: forwardRef(() => SourceGeoJSONComponent) }
+    ]
+})
+export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
+    instance: source.Vector;
+    format: format.Feature;
+    @Input() defaultDataProjection: string;
+    @Input() featureProjection: string;
+    @Input() geometryName: string;
+    @Input() url: string;
+
+    constructor( @Host() layer: LayerVectorComponent) {
+        super(layer);
+    }
+
+    ngOnInit() {
+        this.format = new format.GeoJSON(this);
+        this.instance = new source.Vector(this);
+        this.host.instance.setSource(this.instance);
+    }
+}

--- a/src/components/sources/geojson.component.ts
+++ b/src/components/sources/geojson.component.ts
@@ -1,4 +1,4 @@
-import { Component, Host, Input, OnInit, forwardRef, ContentChild, AfterContentInit } from '@angular/core';
+import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
 import { source, ProjectionLike, format } from 'openlayers';
 import { LayerVectorComponent } from '../layers';
 import { FormatComponent } from '../formats';

--- a/src/components/sources/geojson.component.ts
+++ b/src/components/sources/geojson.component.ts
@@ -15,8 +15,8 @@ import { SourceComponent } from './source.component';
 export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
     instance: source.Vector;
     format: format.Feature;
-    @Input() defaultDataProjection: string;
-    @Input() featureProjection: string;
+    @Input() defaultDataProjection: ProjectionLike;
+    @Input() featureProjection: ProjectionLike;
     @Input() geometryName: string;
     @Input() url: string;
 

--- a/src/components/sources/index.ts
+++ b/src/components/sources/index.ts
@@ -5,3 +5,4 @@ export * from './vector.component';
 export * from './vectortile.component';
 export * from './xyz.component';
 export * from './tilewms.component';
+export * from './geojson.component';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import {
   MapComponent, ViewComponent,
   LayerTileComponent, LayerVectorComponent, LayerVectorTileComponent,
   SourceBingmapsComponent, SourceOsmComponent, SourceVectorComponent, SourceVectorTileComponent, SourceXYZComponent, SourceTileWMSComponent,
-  FeatureComponent,
+  SourceGeoJSONComponent, FeatureComponent,
   GeometryLinestringComponent, GeometryPointComponent, GeometryPolygonComponent,
   CollectionCoordinatesComponent, CoordinateComponent,
   StyleCircleComponent, StyleComponent, StyleFillComponent, StyleIconComponent, StyleStrokeComponent, StyleTextComponent,
   ControlAttributionComponent, ControlFullScreenComponent, ControlMousePositionComponent,
   ControlOverviewMapComponent, ControlRotateComponent, ControlScaleLineComponent, ControlZoomComponent, ControlZoomSliderComponent,
-  ControlZoomToExtentComponent, DefaultControlComponent,  ControlComponent,
+  ControlZoomToExtentComponent, DefaultControlComponent, ControlComponent,
   FormatMVTComponent,
   TileGridComponent,
   DefaultInteractionComponent, DragRotateInteractionComponent, DragRotateAndZoomInteractionComponent,
@@ -39,7 +39,7 @@ const COMPONENTS = [
   SourceXYZComponent,
   SourceVectorTileComponent,
   SourceTileWMSComponent,
-
+  SourceGeoJSONComponent,
   FeatureComponent,
   GeometryLinestringComponent,
   GeometryPointComponent,
@@ -90,4 +90,4 @@ const COMPONENTS = [
   imports: [CommonModule],
   exports: COMPONENTS
 })
-export class AngularOpenlayersModule {}
+export class AngularOpenlayersModule { }


### PR DESCRIPTION
I need to use some GeoJSON format vector layers and started out with the solution from #41 (using afterContentInit) but ran into chicken and egg hell trying to style the layer. Thus, this solution. I can add to the example if this pull is approved. Basic usage (From my project):
```
<aol-layer-vector *ngIf="aol_show_AZ">
    <aol-source-geojson [url]="'/assets/layers/04_AZ_County_Clipped.geojson'">
        <aol-style>
            <aol-style-stroke [color]="'lightblue'" [width]="width"></aol-style-stroke>
        </aol-style>
    </aol-source-geojson>
</aol-layer-vector>
```

