### PR TITLE
Relax version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "main": "./dist/index.js",
     "typings": "./dist/index.d.ts",
     "dependencies": {
-        "openlayers": "4.0.1"
+        "openlayers": "4.0.x || 4.1.x"
     },
     "devDependencies": {
         "@angular/common": "^2.4.1",


### PR DESCRIPTION
With a pinned dependency, we force this specific version of openlayers onto every project using our package.

I've relaxed the check to work with all versions of openlayers whose API we support.

Ideally we should probably turn the `dependency` into a `peerDependency`, then it would be the user's responsibility to require the desired version of openlayers in his/her project.