### PR TITLE
add url and format to source-vector component

### DIFF
--- a/src/components/sources/vector.component.ts
+++ b/src/components/sources/vector.component.ts
@@ -15,6 +15,8 @@ export class SourceVectorComponent extends SourceComponent implements OnInit {
   @Input() overlaps: boolean;
   @Input() useSpatialIndex: boolean;
   @Input() wrapX: boolean;
+  @Input() url: string;
+  @Input() format: ol.format.Feature;
 
   constructor(@Host() layer: LayerVectorComponent) {
     super(layer);


### PR DESCRIPTION
Add `url` and `format` parameters to `aol-source-vector`. 

Openlayer doc: http://openlayers.org/en/latest/apidoc/ol.source.Vector.html
