### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,53 @@
 language: node_js
 sudo: false
 node_js:
-- '4.2.1'
+- '6'
+
+env:
+- NPM_CONFIG_LOGLEVEL='warn'
+
+jobs:
+  include:
+  - stage: build library
+    before_script:
+    - rm -rf lib
+    script:
+    - npm pack
+    - mkdir -p lib
+    - cp *.tgz lib/
+    cache:
+      directories:
+      - lib
+  - stage: build demo
+    before_install:
+    - cd example
+    install:
+    - npm i
+    script:
+    - npm un -S angular2-openlayers
+    - cp -r ../lib .
+    - npm i -S lib/*.tgz
+    - npm run build
+    cache:
+      directories:
+      - lib
+  - stage: deploy library release
+    script: ignore
+    deploy:
+      - provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        file_glob: true
+        file: lib/*
+        skip_cleanup: true
+        on:
+          tags: true
+  - stage: deploy demo pages
+    script: ignore
+    deploy:
+      - provider: pages
+        local_dir: dist
+        skip_cleanup: true
+        github_token: $GITHUB_OAUTH_TOKEN
+        on:
+          tags: true
+

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --env=prod --progress false",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Add continuous integration through Travis tool (https://travis-ci.org/)

**Pipeline is composed by 3 steps :**
1. **Build library** which triggers `npm install` and `npm pack` and stores it in cache for next stage
2. **Build demo** which triggers `npm install` for example cli project and includes built library of the previous stage (via `npm uninstall` and `npm install`)
3. **Deploy library release** which deploys the packed library of the first stage in Github releases when adding tags only
4. **Deploy demo pages** which deploys the example cli project on Github pages (tags only)

**Notices :** 
- test stage is not implemented yet, maybe in a future PR
- don't forget to add the `GITHUB_OAUTH_TOKEN` env var in Travis setting for Github deployments