### PR TITLE
feat(SourceTileWMTSComponent): add wmts source component and wmts grid tile component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/*
 npm-debug.log
 
+# compiled output
+/dist
+
 # JetBrains
 .idea
 .project

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,7 @@
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4",
-    "angular2-openlayers": "^0.6.5"
+    "angular2-openlayers": "0.6.8"
   },
   "devDependencies": {
     "@angular/cli": "1.0.4",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,4 +14,5 @@ export * from './geometry.components';
 export * from './map.component';
 export * from './overlay.component';
 export * from './tilegrid.component';
+export * from './tilegridwmts.component';
 export * from './view.component';

--- a/src/components/sources/index.ts
+++ b/src/components/sources/index.ts
@@ -6,3 +6,4 @@ export * from './vectortile.component';
 export * from './xyz.component';
 export * from './tilewms.component';
 export * from './geojson.component';
+export * from './tilewmts.component';

--- a/src/components/sources/tilewmts.component.ts
+++ b/src/components/sources/tilewmts.component.ts
@@ -1,0 +1,59 @@
+import { Component, Host, Input, OnInit, forwardRef, AfterContentInit , ContentChild } from '@angular/core';
+import {
+    TileLoadFunctionType,
+    AttributionLike,
+    tilegrid,
+    ProjectionLike,
+    source,
+    ImageTile,
+    TileCoord,
+    Tile
+} from 'openlayers';
+import { LayerTileComponent } from '../layers';
+import { SourceComponent } from './source.component';
+import { TileGridWMTSComponent } from '../tilegridwmts.component';
+
+@Component({
+    selector: 'aol-source-tilewmts',
+    template: `<ng-content></ng-content>`,
+    providers: [
+        { provide: SourceComponent, useExisting: forwardRef(() => SourceTileWMTSComponent) }
+    ]
+})
+export class SourceTileWMTSComponent extends SourceComponent implements AfterContentInit  {
+
+    instance: source.WMTS;
+    @Input() cacheSize?: number;
+    @Input() crossOrigin?: (string);
+    @Input() logo?: (string | olx.LogoOptions);
+    @Input() tileGrid: tilegrid.WMTS;
+    @Input() projection: ProjectionLike;
+    @Input() reprojectionErrorThreshold?: number;
+    @Input() requestEncoding?: (source.WMTSRequestEncoding | string);
+    @Input() layer: string;
+    @Input() style: string;
+    @Input() tileClass?: ((n: ImageTile, coords: TileCoord, state: Tile.State, s1: string, s2: string, type: TileLoadFunctionType) => any);
+    @Input() tilePixelRatio?: number;
+    @Input() version?: string;
+    @Input() format?: string;
+    @Input() matrixSet: string;
+    @Input() dimensions?: GlobalObject;
+    @Input() url?: string;
+    @Input() tileLoadFunction?: TileLoadFunctionType;
+    @Input() urls?: string[];
+    @Input() wrapX?: boolean;
+
+    @ContentChild(TileGridWMTSComponent) tileGridWMTS: TileGridWMTSComponent;
+
+    constructor( @Host() layer: LayerTileComponent) {
+        super(layer);
+    }
+
+    ngAfterContentInit(): void {
+        if (this.tileGridWMTS) {
+            this.tileGrid = this.tileGridWMTS.instance;
+            this.instance = new source.WMTS(this);
+            this.host.instance.setSource(this.instance);
+        }
+    }
+}

--- a/src/components/tilegridwmts.component.ts
+++ b/src/components/tilegridwmts.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { tilegrid, Extent, Size, Coordinate } from 'openlayers';
+import { TileGridComponent } from './tilegrid.component';
+
+@Component({
+    selector: 'aol-tilegrid-wmts',
+    template: ''
+})
+export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
+    instance: tilegrid.WMTS;
+
+    @Input() origin?: Coordinate;
+    @Input() origins?: Coordinate[];
+    @Input() resolutions: number[];
+    @Input() matrixIds: string[];
+    @Input() sizes?: Size[];
+    @Input() tileSizes?: ((number | Size)[]);
+    @Input() widths?: number[];
+
+    ngOnInit() {
+        this.instance = new tilegrid.WMTS(this);
+    }
+}

--- a/src/components/view.component.ts
+++ b/src/components/view.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { View, Extent } from 'openlayers';
+import { View, Extent, Coordinate } from 'openlayers';
 import { MapComponent } from './map.component';
 
 @Component({
@@ -22,6 +22,7 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
   @Input() rotation: number;
   @Input() zoom: number;
   @Input() zoomFactor: number;
+  @Input() center: Coordinate;
 
   constructor(private host: MapComponent) {
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
   MapComponent, ViewComponent,
   LayerTileComponent, LayerVectorComponent, LayerVectorTileComponent,
   SourceBingmapsComponent, SourceOsmComponent, SourceVectorComponent, SourceVectorTileComponent, SourceXYZComponent, SourceTileWMSComponent,
-  SourceGeoJSONComponent, FeatureComponent,
+  SourceGeoJSONComponent, SourceTileWMTSComponent, FeatureComponent,
   GeometryLinestringComponent, GeometryPointComponent, GeometryPolygonComponent,
   CollectionCoordinatesComponent, CoordinateComponent,
   StyleCircleComponent, StyleComponent, StyleFillComponent, StyleIconComponent, StyleStrokeComponent, StyleTextComponent,
@@ -12,7 +12,7 @@ import {
   ControlOverviewMapComponent, ControlRotateComponent, ControlScaleLineComponent, ControlZoomComponent, ControlZoomSliderComponent,
   ControlZoomToExtentComponent, DefaultControlComponent, ControlComponent,
   FormatMVTComponent,
-  TileGridComponent,
+  TileGridComponent, TileGridWMTSComponent,
   DefaultInteractionComponent, DragRotateInteractionComponent, DragRotateAndZoomInteractionComponent,
   DoubleClickZoomInteractionComponent, DragAndDropInteractionComponent, DragBoxInteractionComponent,
   DragPanInteractionComponent, DragZoomInteractionComponent, MouseWheelZoomInteractionComponent,
@@ -40,6 +40,7 @@ const COMPONENTS = [
   SourceXYZComponent,
   SourceVectorTileComponent,
   SourceTileWMSComponent,
+  SourceTileWMTSComponent,
   SourceGeoJSONComponent,
   FeatureComponent,
   GeometryLinestringComponent,
@@ -69,6 +70,7 @@ const COMPONENTS = [
 
   FormatMVTComponent,
   TileGridComponent,
+  TileGridWMTSComponent,
 
   DefaultInteractionComponent,
   DoubleClickZoomInteractionComponent,


### PR DESCRIPTION
Grid tile wmts has to be a child component of wms source to be compliant
with Openlayers architecture. 

As the tileGrid parameter of source WMTS
is mandatory, source intance is created after content initialization
with tile grid child component instance as value for tileGrid

@davinkevin @Neonox31 @Yann29